### PR TITLE
Fix unicode issues.

### DIFF
--- a/Serialization/String.cs
+++ b/Serialization/String.cs
@@ -91,6 +91,11 @@ namespace CER.JSON.DocumentObjectModel
 						throw new FormatException("Value contains a control character.");
 					}
 
+					if (IsUnpairedSurrogate(value, i))
+					{
+						throw new FormatException("Value contains an unpaired surrogate.");
+					}
+
 					if (isEscaped)
 					{
 						isEscaped = false;
@@ -221,6 +226,22 @@ namespace CER.JSON.DocumentObjectModel
 		private static string EscapeChar(char character)
 		{
 			return string.Format(CultureInfo.InvariantCulture, "\\u{0:X4}", (ushort)character);
+		}
+
+		private static bool IsUnpairedSurrogate(string value, int index)
+		{
+			if (char.IsHighSurrogate(value[index]))
+			{
+				return index == value.Length - 1 || !char.IsLowSurrogate(value[index + 1]);
+			}
+			else if (char.IsLowSurrogate(value[index]))
+			{
+				return index == 0 || !char.IsHighSurrogate(value[index - 1]);
+			}
+			else
+			{
+				return false;
+			}
 		}
 	}
 }


### PR DESCRIPTION
If unpaired surrogates would be set as the JSON value of a JSON string, throw an exception. The JSON value must always be valid JSON.
Unpaired UTF-16 surrogates cannot be read from a stream. The decoder would throw an exception or replace them.
If unpaired surrogates are set as the native value of a JSON string, they should be escaped in the JSON representation.
When serializing a JSON string, detect code points that cannot be represented in the target encoding (e.g. emoji characters are written to an ASCII stream) and replace them with escaped UTF-16 code units.